### PR TITLE
Add subcomponent support for GitHub provider

### DIFF
--- a/.changeset/bumpy-monkeys-watch.md
+++ b/.changeset/bumpy-monkeys-watch.md
@@ -1,0 +1,5 @@
+---
+"issue-status": patch
+---
+
+Add support for sub-components

--- a/packages/issue-status/src/components/Component.tsx
+++ b/packages/issue-status/src/components/Component.tsx
@@ -43,7 +43,8 @@ export const Component = ({ name, status, children }: ComponentType) => {
         onClick={() => setShowChildren(!showChildren)}
         clickable={isClickable}
       >
-        {children ? chevron : null} {name} <Badge status={status} />
+        {children ? chevron : null} {name}{" "}
+        {status === "unknown" && children ? null : <Badge status={status} />}
       </Box>
       {showChildren
         ? children?.map((child) => (


### PR DESCRIPTION
You can now group components under a parent component. This works similar to https://www.cloudflarestatus.com

It can be especially useful for status pages with a large amount of components.

You must follow a specific GitHub Issue title syntax:

- `parent`
- `parent > child`

This will render with the child nested under the parent.

<img width="598" alt="Screenshot 2025-06-17 at 10 10 44 pm" src="https://github.com/user-attachments/assets/2ae0946c-11ec-472d-a27c-71f18062bf03" />

